### PR TITLE
Dbre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.1 - 1.12.2021
+
+### Features
+
+* -r/--recent option to show summaries of the most recent runs
+
+### Changes
+
+* Standard and script test results are now saved in a single table
+
 ## v0.3.0 - 10.11.2021
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smokey"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smokey"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["ukmrs <murias.wstork@gmail.com>"]
 edition = "2018"
 description = "Handsome TUI typing test"

--- a/src/database/history.rs
+++ b/src/database/history.rs
@@ -1,0 +1,149 @@
+use crate::settings;
+use rusqlite::{self, Connection};
+use std::io::{self, BufWriter, Write};
+
+const CLI_HISTORY_STATEMENT: &str = r#"SELECT 
+
+wpm,
+acc,
+test.test_name,
+mods,
+correct_chars,
+mistakes,
+datetime(date, 'unixepoch', 'localtime'),
+length,
+word_pool
+
+FROM run
+INNER JOIN test ON test.test_id = run.test_id
+ORDER BY run_id desc
+LIMIT ?;
+"#;
+
+fn decode(bitflag: u8) -> String {
+    let mut result = String::from(" ");
+
+    for i in 0..3 {
+        if bitflag >> i & 1 == 1 {
+            match i {
+                0 => result.push_str(settings::PUNCTUATION_SHORTHAND),
+                1 => result.push_str(settings::NUMBERS_SHORTHAND),
+                2 => result.push_str(settings::SYMBOLS_SHORTHAND),
+                _ => unreachable!(),
+            }
+        };
+    }
+
+    result
+}
+
+pub struct History {
+    som: Vec<EntryCell>,
+    justing: JustingInfo,
+}
+
+impl History {
+    pub fn print(&self) {
+        let stdout = io::stdout();
+        let lock = stdout.lock();
+        let mut buff = BufWriter::new(lock);
+
+        let clen = format!("{}", self.justing.correct).len();
+
+        writeln!(
+            buff,
+            "{:6}|{:6}|{:clen$}|{:3}",
+            "wpm",
+            "acc",
+            "c",
+            "mis",
+            clen = clen
+        )
+        .expect("couldn't write to stdout");
+        for a in &self.som {
+            writeln!(
+                buff,
+                "{:6}|{:6}|{:<w$}|{:<3}|{:width$}|{}",
+                format!("{:.2}", a.wpm),
+                format!("{:.2}", a.acc),
+                a.correct,
+                a.mis,
+                a.name,
+                a.date,
+                width = self.justing.name_len,
+                w = clen,
+            )
+            .expect("oof: couldn't write to stdout")
+        }
+        buff.flush().expect("oof: couldn't flush to stdout");
+    }
+}
+
+#[derive(Debug)]
+struct EntryCell {
+    wpm: f64,
+    acc: f64,
+    correct: usize,
+    mis: usize,
+    name: String,
+    date: String,
+}
+
+#[derive(Debug, Default)]
+struct JustingInfo {
+    name_len: usize,
+    correct: usize,
+}
+
+impl JustingInfo {
+    fn update(&mut self, entry_cell: &EntryCell) {
+        if entry_cell.name.len() > self.name_len {
+            self.name_len = entry_cell.name.len()
+        }
+        self.correct = std::cmp::max(self.correct, entry_cell.correct)
+    }
+}
+
+pub fn get_history(conn: &Connection, limit: usize) -> Result<History, rusqlite::Error> {
+    let mut stmt = conn.prepare(CLI_HISTORY_STATEMENT)?;
+    let mut justing = JustingInfo::default();
+
+    let rows = stmt.query_map([limit], |row| {
+        let name: String;
+        let word_pool: usize = row.get(8)?;
+
+        if word_pool == 0 {
+            name = row.get(2)?;
+        } else {
+            let raw_name: String = row.get(2)?;
+            let length: usize = row.get(7)?;
+            name = format!(
+                "{} {}/{}{}",
+                raw_name,
+                length,
+                word_pool,
+                decode(row.get(3)?)
+            );
+        }
+
+        let s = EntryCell {
+            wpm: row.get(0)?,
+            acc: row.get(1)?,
+            correct: row.get(4)?,
+            mis: row.get(5)?,
+            name,
+            date: row.get(6)?,
+        };
+
+        justing.update(&s);
+        Ok(s)
+    })?;
+
+    // It would oof earlier than this unwrap anyway right? xD
+    let container: Vec<EntryCell> = rows.map(|x| x.unwrap()).collect();
+
+    Ok(History {
+        som: container,
+        justing,
+    })
+}

--- a/src/database/init.rs
+++ b/src/database/init.rs
@@ -15,9 +15,6 @@ pub fn init_db(conn: &mut Connection) -> SqlResult<()> {
 
     test_table_init(&tx)?;
     run_table_init(&tx)?;
-    mod_table_init(&tx)?;
-    script_table_init(&tx)?;
-    run_script_table_init(&tx)?;
 
     tx.commit()?;
 
@@ -50,45 +47,6 @@ fn run_table_init(conn: &Connection) -> SqlResult<()> {
     mods INTEGER NOT NULL,
     FOREIGN KEY (test_id) REFERENCES test (test_id) ON DELETE CASCADE
     );",
-        [],
-    )?;
-    Ok(())
-}
-
-fn script_table_init(conn: &Connection) -> SqlResult<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS script (
-    script_id INTEGER PRIMARY KEY,
-    script_name TEXT UNIQUE
-    );",
-        [],
-    )?;
-    Ok(())
-}
-
-fn run_script_table_init(conn: &Connection) -> SqlResult<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS srun (
-    run_id INTEGER PRIMARY KEY,
-    date INTEGER NOT NULL,
-    script_id INTEGER NOT NULL,
-    correct_chars INTEGER NOT NULL,
-    mistakes INTEGER NOT NULL,
-    wpm REAL NOT NULL,
-    acc REAL NOT NULL,
-    FOREIGN KEY (script_id) REFERENCES script (script_id)
-    );",
-        [],
-    )?;
-    Ok(())
-}
-
-fn mod_table_init(conn: &Connection) -> SqlResult<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS mod (
-        mod_id INTEGER PRIMARY KEY,
-        mod_name TEXT UNIQUE
-        );",
         [],
     )?;
     Ok(())

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,3 +1,4 @@
+pub mod history;
 pub mod init;
 use crate::settings::{TestMod, TestVariant, TypingTestConfig, BITFLAG_MODS};
 use crate::storage;
@@ -47,6 +48,12 @@ impl RunHistoryDatbase {
             sum.correct_chars, sum.mistakes, sum.wpm, sum.acc],
             )
             .expect("inserting into run");
+    }
+
+    pub fn print_history(&self, limit: usize) {
+        history::get_history(&self.conn, limit)
+            .expect("could")
+            .print();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@
 //! by ukmrs https://github.com/ukmrs/smokey
 //! A simple typing test terminal UI app
 
-use smokey::{application::App, storage};
+use smokey::{application::App, database, storage};
+
 use std::io::stdout;
 use structopt::StructOpt;
 use tui::{backend::CrosstermBackend, Terminal};
@@ -25,20 +26,23 @@ fn main() -> crossterm::Result<()> {
 
     let app = App::from_config();
 
-
     smokey::run(app, terminal)?;
     Ok(())
 }
 
 #[derive(StructOpt)]
 struct Opt {
-    /// prints expected path of the smokey config file
+    /// Prints expected path of the smokey config file
     #[structopt(short, long)]
     config: bool,
 
-    /// prints path of the smokey storage directory
+    /// Prints path of the smokey storage directory
     #[structopt(short, long)]
     storage: bool,
+
+    /// Prints out summaries of n most recent runs
+    #[structopt(short, long, name = "n")]
+    recent: Option<Option<usize>>,
 }
 
 fn execute_info_requests(opt: &Opt) -> bool {
@@ -51,6 +55,12 @@ fn execute_info_requests(opt: &Opt) -> bool {
     if opt.config {
         should_exit = true;
         println!("{}", storage::get_config_file().to_str().unwrap())
+    }
+
+    if let Some(us) = opt.recent {
+        let history_lines = us.unwrap_or(12);
+        should_exit = true;
+        database::RunHistoryDatbase::default().print_history(history_lines);
     }
 
     should_exit

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> crossterm::Result<()> {
 
     let app = App::from_config();
 
+
     smokey::run(app, terminal)?;
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,10 @@ pub const SCRIPT_SIGN: &str = "#!";
 use bimap::BiMap;
 use lazy_static::lazy_static;
 
+pub const PUNCTUATION_SHORTHAND: &str = "!?";
+pub const NUMBERS_SHORTHAND: &str = "17";
+pub const SYMBOLS_SHORTHAND: &str = "#$";
+
 lazy_static! {
     pub static ref TEST_MODS: BiMap<&'static str, TestMod> = [
         ("punctuation", TestMod::Punctuation),


### PR DESCRIPTION
Change how runs summaries are saved; they're now saved in a single table
added a --recent <n> option to print the most recent runs